### PR TITLE
Fix vercel function runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.js": {
-      "runtime": "vercel/node@20.x"
+      "runtime": "nodejs20.x"
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- fix runtime string in `vercel.json` to use `nodejs20.x`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862c78ab694832eb55ae0928dea6f48