### PR TITLE
Fix vercel runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.js": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs18.x"
     }
-  },
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/bin/www"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- remove invalid route pointing to missing server file
- set function runtime to nodejs18.x

## Testing
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6862d34eb4bc832ebc3d11afd4082424